### PR TITLE
added missing include for std::round

### DIFF
--- a/Sources/ReconstructionData.cxx
+++ b/Sources/ReconstructionData.cxx
@@ -31,6 +31,7 @@
 #include "ReconstructionData.h"
 
 #include <sstream>
+#include <cmath>
 
 // VTK includes
 #include "vtkDoubleArray.h"


### PR DESCRIPTION
This was causing a build error on OS X
